### PR TITLE
.pylintrc: fix typos

### DIFF
--- a/.pylintrc
+++ b/.pylintrc
@@ -16,13 +16,13 @@ recursive=yes # Default: False
 
 # To disable more rules, see output of pylint. E.g.
 # [...] C0301: Line too long (89/80) (line-too-long)
-# can be surpressed with either disable=line-too-long or disable=C
+# can be suppressed with either disable=line-too-long or disable=C
 # It is also possible to ignore a specific line by adding
 # # pylint: disable=broad-exception-caught
 # above the line causing the lint error
 disable=
         W, ; all Warnings are allowed to fail
-        import-error, ; To surpress e.g "Unable to import 'grass.script"
+        import-error, ; To suppress e.g "Unable to import 'grass.script"
         missing-module-docstring, ; we use the GRASS GIS header
         R, ; refactoring + design recommendations
 


### PR DESCRIPTION
Typos found with

https://github.com/OSGeo/grass/blob/main/utils/fix_typos.sh