### PR TITLE
adapted to run with FORCE Version 3.10.00 and added feature 

### DIFF
--- a/README.md
+++ b/README.md
@@ -127,6 +127,7 @@ south: 45.67          # AOI boundary in decimal degree
 east: 11.97           # AOI boundary in decimal degree
 west: 10.44           # AOI boundary in decimal degree
 cloud_cover: 75       # maximum percentage of cloud cover in scene
+products: ['S2_MSI_L1C', 'LANDSAT_C2L1']   # satellite products to download
 ```
 
 ##### FORCE & postprocessing options

--- a/config_example.yaml
+++ b/config_example.yaml
@@ -39,6 +39,20 @@ end: '2023-08-15'
 # type=int, help='Max. cloud cover (1-100) of scenes to download.'
 cloud_cover: 100
 
+# type=list, help='Satellite products to download and process. Note: the according credentials must be provided in the eodag.yaml for the specific products'
+# examples:
+#   products:
+#     - S2_MSI_L1C      Only Sentinel 2
+#
+#   products:
+#     - LANDSAT_C2L1    Only Landsat
+#
+#   products:
+#     - S2_MSI_L1C      Both Sentinel & Landsat
+#     - LANDSAT_C2L1
+products:
+  - S2_MSI_L1C
+
 # type=str, help='Path to folder where output is stored'
 output_dir: '/path/to/output/dir/'
 

--- a/sadasadam/cli.py
+++ b/sadasadam/cli.py
@@ -139,6 +139,9 @@ def main():
         cloud_cover = config.get("cloud_cover")
         if not cloud_cover:
             raise Exception("Please provide a maximum cloud cover")
+        products = config.get("products")
+        if not products:
+            raise Exception("Please provide at least one satellite product to download")
         output_dir = config.get("output_dir")
         if not output_dir:
             raise Exception("Please provide an output directory")
@@ -256,8 +259,6 @@ def main():
         # Start Downloading
 
         if force_only is False:
-            # define satellite products
-            products = ["S2_MSI_L1C", "LANDSAT_C2L1"]
             # define geometry
             geom = {
                 "lonmin": west,

--- a/sadasadam/force.py
+++ b/sadasadam/force.py
@@ -20,7 +20,7 @@
 #
 ############################################################################
 
-# Developed and tested for FORCE version 3.7.11
+# Developed and tested for FORCE version 3.7.11 - adapted to use with FORCE version 3.10.00
 import os
 import shutil
 from subprocess import Popen, PIPE
@@ -344,7 +344,7 @@ class ForceProcess(object):
         cmd_list = [
             "force-mosaic",
             "-m",
-            self.mosaic_dir_name,
+            self.mosaic_path,
             self.level2_dir,
         ]
         run_subprocess(cmd_list)


### PR DESCRIPTION
- adapted SADASADAM to run with FORCE Version 3.10.00, for this a change in "run_force_mosaic" function was necessary
- added a feature to define the desired dataset (Sentinel-2, Landsat or both) in the SADASADAM config file ("products"), the process would previously always search for and download both Sentinel and Landsat scenes 